### PR TITLE
Implement Req/Res Protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -656,16 +656,21 @@ dependencies = [
  "eth2_ssz_derive",
  "eth2_ssz_types",
  "ethereum-types 0.14.1",
+ "fnv",
  "futures",
  "libp2p",
  "primitive-types 0.12.1",
  "serde",
  "serde_derive",
  "sha2 0.10.6",
+ "smallvec",
  "snap",
  "tokio",
+ "tokio-io-timeout",
+ "tokio-util 0.6.10",
  "tree_hash",
  "tree_hash_derive",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -4481,6 +4486,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-io-timeout"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
+dependencies = [
+ "pin-project-lite 0.2.9",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-macros"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4510,6 +4525,7 @@ checksum = "36943ee01a6d67977dd3f84a5a1d2efeb4ada3a1ae771cadfaa535d9d9fc6507"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "log",
  "pin-project-lite 0.2.9",
@@ -4755,6 +4771,7 @@ dependencies = [
  "bytes",
  "futures-io",
  "futures-util",
+ "tokio-util 0.6.10",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokio = { version = "1.23.0", features = ["full", "rt-multi-thread", "time","macros"] }
+tokio = { version = "1.23.0", features = ["full", "rt-multi-thread", "time", "macros"] }
 libp2p =  { version = "0.50.0", features = ["full", "tcp", "dns", "websocket", "tokio", "identify", "mplex", "yamux", "noise", "gossipsub"] }
 discv5 = { version = "0.1.0", features = ["libp2p"] }
 futures =  "0.3.25"
@@ -21,3 +21,8 @@ serde = "1.0.152"
 primitive-types = "0.12.1"
 snap = "1.1.0"
 sha2 = "0.10.6"
+unsigned-varint = {version = "0.7.1", features = ["codec"]}
+tokio-util = { version = "0.6.10", features = ["codec", "compat", "time"] }
+smallvec = "1.10.0"
+fnv = "1.0.7"
+tokio-io-timeout = "1.2.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ mod chain;
 mod config;
 mod discovery;
 mod enr;
+mod rpc;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/src/rpc/codec/base.rs
+++ b/src/rpc/codec/base.rs
@@ -1,7 +1,6 @@
 use crate::rpc::{
     methods::{ErrorType, RPCCodedResponse, RPCResponse},
-    outbound::OutboundRequest,
-    protocol::InboundRequest,
+    protocol::{InboundRequest, OutboundRequest},
 };
 use libp2p::bytes::{BufMut, BytesMut};
 use tokio_util::codec::{Decoder, Encoder};

--- a/src/rpc/codec/base.rs
+++ b/src/rpc/codec/base.rs
@@ -121,7 +121,7 @@ where
             } else {
                 self.inner
                     .decode_error(src)
-                    .map(|r| r.map(|resp| RPCCodedResponse::from_error(response_code, resp)))
+                    .map(|r| r.map(|_| RPCCodedResponse::Error))
             }
         };
 

--- a/src/rpc/codec/base.rs
+++ b/src/rpc/codec/base.rs
@@ -1,0 +1,139 @@
+use crate::rpc::{
+    methods::{ErrorType, RPCCodedResponse, RPCResponse},
+    outbound::OutboundRequest,
+    protocol::InboundRequest,
+};
+use libp2p::bytes::{BufMut, BytesMut};
+use tokio_util::codec::{Decoder, Encoder};
+
+pub trait OutboundCodec<TItem>: Encoder<TItem> + Decoder {
+    type CodecErrorType;
+
+    fn decode_error(
+        &mut self,
+        src: &mut BytesMut,
+    ) -> Result<Option<Self::CodecErrorType>, <Self as Decoder>::Error>;
+}
+
+// Inbound codec
+pub struct BaseInboundCodec<TCodec>
+where
+    TCodec: Encoder<RPCCodedResponse> + Decoder,
+{
+    inner: TCodec,
+}
+
+impl<TCodec> BaseInboundCodec<TCodec>
+where
+    TCodec: Encoder<RPCCodedResponse> + Decoder,
+{
+    pub fn new(codec: TCodec) -> Self {
+        BaseInboundCodec { inner: codec }
+    }
+}
+
+impl<TCodec> Encoder<RPCCodedResponse> for BaseInboundCodec<TCodec>
+where
+    TCodec: Decoder + Encoder<RPCCodedResponse>,
+{
+    type Error = <TCodec as Encoder<RPCCodedResponse>>::Error;
+
+    fn encode(&mut self, item: RPCCodedResponse, dst: &mut BytesMut) -> Result<(), Self::Error> {
+        dst.clear();
+        dst.reserve(1);
+        dst.put_u8(
+            item.as_u8()
+                .expect("Should never encode a stream termination"),
+        );
+        self.inner.encode(item, dst)
+    }
+}
+
+impl<TCodec> Decoder for BaseInboundCodec<TCodec>
+where
+    TCodec: Encoder<RPCCodedResponse> + Decoder<Item = InboundRequest>,
+{
+    type Item = InboundRequest;
+    type Error = <TCodec as Decoder>::Error;
+
+    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        self.inner.decode(src)
+    }
+}
+
+// Outbound Codec
+
+pub struct BaseOutboundCodec<TOutboundCodec>
+where
+    TOutboundCodec: OutboundCodec<OutboundRequest>,
+{
+    inner: TOutboundCodec,
+    current_response_code: Option<u8>,
+}
+
+impl<TOutboundCodec> BaseOutboundCodec<TOutboundCodec>
+where
+    TOutboundCodec: OutboundCodec<OutboundRequest>,
+{
+    pub fn new(codec: TOutboundCodec) -> Self {
+        BaseOutboundCodec {
+            inner: codec,
+            current_response_code: None,
+        }
+    }
+}
+
+impl<TCodec> Encoder<OutboundRequest> for BaseOutboundCodec<TCodec>
+where
+    TCodec: OutboundCodec<OutboundRequest> + Encoder<OutboundRequest>,
+{
+    type Error = <TCodec as Encoder<OutboundRequest>>::Error;
+
+    fn encode(&mut self, item: OutboundRequest, dst: &mut BytesMut) -> Result<(), Self::Error> {
+        self.inner.encode(item, dst)
+    }
+}
+
+impl<TCodec> Decoder for BaseOutboundCodec<TCodec>
+where
+    TCodec:
+        OutboundCodec<OutboundRequest, CodecErrorType = ErrorType> + Decoder<Item = RPCResponse>,
+{
+    type Item = RPCCodedResponse;
+    type Error = <TCodec as Decoder>::Error;
+
+    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        // if we have only received the response code, wait for more bytes
+        if src.len() <= 1 {
+            return Ok(None);
+        }
+        // using the response code determine which kind of payload needs to be decoded.
+        let response_code = self.current_response_code.unwrap_or_else(|| {
+            let resp_code = src.split_to(1)[0];
+            self.current_response_code = Some(resp_code);
+            resp_code
+        });
+
+        let inner_result = {
+            if RPCCodedResponse::is_response(response_code) {
+                // decode an actual response and mutates the buffer if enough bytes have been read
+                // returning the result.
+                self.inner
+                    .decode(src)
+                    .map(|r| r.map(RPCCodedResponse::Success))
+            } else {
+                // decode an error
+                self.inner
+                    .decode_error(src)
+                    .map(|r| r.map(|resp| RPCCodedResponse::from_error(response_code, resp)))
+            }
+        };
+        // if the inner decoder was capable of decoding a chunk, we need to reset the current
+        // response code for the next chunk
+        if let Ok(Some(_)) = inner_result {
+            self.current_response_code = None;
+        }
+        // return the result
+        inner_result
+    }
+}

--- a/src/rpc/codec/mod.rs
+++ b/src/rpc/codec/mod.rs
@@ -1,0 +1,60 @@
+pub(crate) mod base;
+pub(crate) mod ssz_snappy;
+use self::base::{BaseInboundCodec, BaseOutboundCodec};
+use self::ssz_snappy::{SSZSnappyInboundCodec, SSZSnappyOutboundCodec};
+use crate::rpc::protocol::RPCError;
+use crate::rpc::{InboundRequest, OutboundRequest, RPCCodedResponse};
+use libp2p::bytes::BytesMut;
+use tokio_util::codec::{Decoder, Encoder};
+
+// The inbound codec for the RPC protocol.
+pub enum InboundCodec {
+    SSZSnappy(BaseInboundCodec<SSZSnappyInboundCodec>),
+}
+
+impl Encoder<RPCCodedResponse> for InboundCodec {
+    type Error = RPCError;
+
+    fn encode(&mut self, item: RPCCodedResponse, dst: &mut BytesMut) -> Result<(), Self::Error> {
+        match self {
+            InboundCodec::SSZSnappy(codec) => codec.encode(item, dst),
+        }
+    }
+}
+
+impl Decoder for InboundCodec {
+    type Item = InboundRequest;
+    type Error = RPCError;
+
+    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        match self {
+            InboundCodec::SSZSnappy(codec) => codec.decode(src),
+        }
+    }
+}
+
+// The outbound codec for the RPC protocol.
+pub enum OutboundCodec {
+    SSZSnappy(BaseOutboundCodec<SSZSnappyOutboundCodec>),
+}
+
+impl Encoder<OutboundRequest> for OutboundCodec {
+    type Error = RPCError;
+
+    fn encode(&mut self, item: OutboundRequest, dst: &mut BytesMut) -> Result<(), Self::Error> {
+        match self {
+            OutboundCodec::SSZSnappy(codec) => codec.encode(item, dst),
+        }
+    }
+}
+
+impl Decoder for OutboundCodec {
+    type Item = RPCCodedResponse;
+    type Error = RPCError;
+
+    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        match self {
+            OutboundCodec::SSZSnappy(codec) => codec.decode(src),
+        }
+    }
+}

--- a/src/rpc/codec/ssz_snappy.rs
+++ b/src/rpc/codec/ssz_snappy.rs
@@ -1,0 +1,264 @@
+use crate::rpc::{
+    methods::{ErrorType, MetaData, RPCCodedResponse, RPCResponse},
+    outbound::OutboundRequest,
+    protocol::{InboundRequest, Protocol, ProtocolId, RPCError, MAX_RPC_SIZE_POST_MERGE},
+};
+use libp2p::bytes::BytesMut;
+use snap::{read::FrameDecoder, write::FrameEncoder};
+use ssz::{Decode, Encode};
+use ssz_types::VariableList;
+use std::io::{Cursor, Read, Write};
+use tokio_util::codec::{Decoder, Encoder};
+use unsigned_varint::codec::Uvi;
+
+use super::base::OutboundCodec;
+
+const CONTEXT_BYTES_LEN: usize = 4;
+
+// Outbound Codec
+
+pub struct SSZSnappyInboundCodec {
+    protocol: ProtocolId,
+    inner: Uvi<usize>,
+    len: Option<usize>,
+}
+
+impl SSZSnappyInboundCodec {
+    fn new(protocol: ProtocolId) -> Self {
+        Self {
+            protocol,
+            inner: Uvi::default(),
+            len: None,
+        }
+    }
+}
+
+impl Encoder<RPCCodedResponse> for SSZSnappyInboundCodec {
+    type Error = RPCError;
+
+    fn encode(
+        &mut self,
+        item: RPCCodedResponse,
+        _dst: &mut libp2p::bytes::BytesMut,
+    ) -> Result<(), Self::Error> {
+        let _bytes = match &item {
+            RPCCodedResponse::Success(m) => println!("{m:?}"),
+            RPCCodedResponse::Error => (),
+            RPCCodedResponse::StreamTermination => (),
+        };
+
+        Ok(())
+    }
+}
+
+impl Decoder for SSZSnappyInboundCodec {
+    type Item = InboundRequest;
+    type Error = RPCError;
+
+    fn decode(
+        &mut self,
+        src: &mut libp2p::bytes::BytesMut,
+    ) -> Result<Option<Self::Item>, Self::Error> {
+        if self.protocol.message_name == Protocol::MetaData {
+            return Ok(Some(InboundRequest::MetaData));
+        }
+
+        let length = match handle_length(&mut self.inner, &mut self.len, src)? {
+            Some(len) => len,
+            None => return Ok(None),
+        };
+
+        let ssz_limits = self.protocol.rpc_response_limits();
+
+        if ssz_limits.is_out_of_bounds(length, MAX_RPC_SIZE_POST_MERGE) {
+            return Err(RPCError::Error);
+        }
+
+        let max_compressed_len = snap::raw::max_compress_len(length) as u64;
+
+        let limit_reader = Cursor::new(src.as_ref()).take(max_compressed_len);
+        let mut reader = FrameDecoder::new(limit_reader);
+
+        let mut decoded_buffer = vec![0; length];
+
+        match reader.read_exact(&mut decoded_buffer) {
+            Ok(()) => {
+                let n = reader.get_ref().get_ref().position();
+                self.len = None;
+                let _read_bytes = src.split_to(n as usize);
+
+                if self.protocol.message_name == Protocol::MetaData {
+                    if !decoded_buffer.is_empty() {
+                        Err(RPCError::Error)
+                    } else {
+                        Ok(Some(InboundRequest::MetaData))
+                    }
+                } else {
+                    return Err(RPCError::Error);
+                }
+            }
+            Err(_) => Err(RPCError::Error),
+        }
+    }
+}
+
+pub fn handle_length(
+    uvi_codec: &mut Uvi<usize>,
+    len: &mut Option<usize>,
+    bytes: &mut BytesMut,
+) -> Result<Option<usize>, RPCError> {
+    if let Some(length) = len {
+        Ok(Some(*length))
+    } else {
+        match uvi_codec.decode(bytes).map_err(RPCError::from)? {
+            Some(length) => {
+                *len = Some(length as usize);
+                Ok(Some(length))
+            }
+            None => Ok(None),
+        }
+    }
+}
+
+// Outbound Codec
+
+pub struct SSZSnappyOutboundCodec {
+    protocol: ProtocolId,
+    inner: Uvi<usize>,
+    len: Option<usize>,
+}
+
+impl SSZSnappyOutboundCodec {
+    fn new(protocol: ProtocolId) -> Self {
+        Self {
+            protocol,
+            inner: Uvi::default(),
+            len: None,
+        }
+    }
+}
+
+impl Encoder<OutboundRequest> for SSZSnappyOutboundCodec {
+    type Error = RPCError;
+
+    fn encode(&mut self, item: OutboundRequest, dst: &mut BytesMut) -> Result<(), Self::Error> {
+        let bytes = match item {
+            OutboundRequest::Status(req) => req.as_ssz_bytes(),
+            OutboundRequest::Goodbye(req) => req.as_ssz_bytes(),
+            OutboundRequest::Ping(req) => req.as_ssz_bytes(),
+            OutboundRequest::MetaData => return Ok(()),
+        };
+
+        if bytes.len() > MAX_RPC_SIZE_POST_MERGE {
+            return Err(RPCError::Error);
+        }
+
+        self.inner
+            .encode(bytes.len(), dst)
+            .map_err(RPCError::from)?;
+
+        let mut writer = FrameEncoder::new(Vec::new());
+        writer.write_all(&bytes).map_err(RPCError::from)?;
+        writer.flush().map_err(RPCError::from)?;
+
+        // Write compressed bytes to `dst`
+        dst.extend_from_slice(writer.get_ref());
+        Ok(())
+    }
+}
+
+impl Decoder for SSZSnappyOutboundCodec {
+    type Item = RPCResponse;
+    type Error = RPCError;
+
+    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        if self.protocol.has_context_bytes() {
+            if src.len() >= CONTEXT_BYTES_LEN {
+                let context_bytes = src.split_to(CONTEXT_BYTES_LEN);
+                let mut result = [0; CONTEXT_BYTES_LEN];
+                result.copy_from_slice(context_bytes.as_ref());
+            } else {
+                return Ok(None);
+            }
+        }
+        let length = match handle_length(&mut self.inner, &mut self.len, src)? {
+            Some(len) => len,
+            None => return Ok(None),
+        };
+
+        let ssz_limits = self.protocol.rpc_response_limits();
+
+        if ssz_limits.is_out_of_bounds(length, MAX_RPC_SIZE_POST_MERGE) {
+            return Err(RPCError::Error);
+        }
+
+        // Calculate worst case compression length for given uncompressed length
+        let max_compressed_len = snap::raw::max_compress_len(length) as u64;
+        // Create a limit reader as a wrapper that reads only upto `max_compressed_len` from `src`.
+        let limit_reader = Cursor::new(src.as_ref()).take(max_compressed_len);
+        let mut reader = FrameDecoder::new(limit_reader);
+
+        let mut decoded_buffer = vec![0; length];
+
+        match reader.read_exact(&mut decoded_buffer) {
+            Ok(()) => {
+                let n = reader.get_ref().get_ref().position();
+                self.len = None;
+                let _read_bytes = src.split_to(n as usize);
+
+                if self.protocol.message_name == Protocol::MetaData {
+                    if !decoded_buffer.is_empty() {
+                        Err(RPCError::Error)
+                    } else {
+                        // TODO: Fix unwrap
+                        Ok(Some(RPCResponse::MetaData(
+                            MetaData::from_ssz_bytes(&decoded_buffer).unwrap(),
+                        )))
+                    }
+                } else {
+                    return Err(RPCError::Error);
+                }
+            }
+            Err(_) => Err(RPCError::Error),
+        }
+    }
+}
+
+impl OutboundCodec<OutboundRequest> for SSZSnappyOutboundCodec {
+    type CodecErrorType = ErrorType;
+
+    fn decode_error(
+        &mut self,
+        src: &mut BytesMut,
+    ) -> Result<Option<Self::CodecErrorType>, RPCError> {
+        let length = match handle_length(&mut self.inner, &mut self.len, src)? {
+            Some(len) => len,
+            None => return Ok(None),
+        };
+
+        // Should not attempt to decode rpc chunks with `length > max_packet_size` or not within bounds of
+        // packet size for ssz container corresponding to `ErrorType`.
+        if length > MAX_RPC_SIZE_POST_MERGE {
+            return Err(RPCError::Error);
+        }
+
+        // Calculate worst case compression length for given uncompressed length
+        let max_compressed_len = snap::raw::max_compress_len(length) as u64;
+        // Create a limit reader as a wrapper that reads only upto `max_compressed_len` from `src`.
+        let limit_reader = Cursor::new(src.as_ref()).take(max_compressed_len);
+        let mut reader = FrameDecoder::new(limit_reader);
+        let mut decoded_buffer = vec![0; length];
+        match reader.read_exact(&mut decoded_buffer) {
+            Ok(()) => {
+                // `n` is how many bytes the reader read in the compressed stream
+                let n = reader.get_ref().get_ref().position();
+                self.len = None;
+                let _read_bytes = src.split_to(n as usize);
+                Ok(Some(ErrorType(
+                    VariableList::from_ssz_bytes(&decoded_buffer).or(Err(RPCError::Error))?,
+                )))
+            }
+            Err(_) => Err(RPCError::Error),
+        }
+    }
+}

--- a/src/rpc/codec/ssz_snappy.rs
+++ b/src/rpc/codec/ssz_snappy.rs
@@ -1,7 +1,9 @@
+use super::base::OutboundCodec;
 use crate::rpc::{
     methods::{ErrorType, MetaData, RPCCodedResponse, RPCResponse},
     protocol::{
-        InboundRequest, OutboundRequest, Protocol, ProtocolId, RPCError, MAX_RPC_SIZE_POST_MERGE,
+        InboundRequest, OutboundRequest, Protocol, ProtocolId, RPCError, Version,
+        MAX_RPC_SIZE_POST_MERGE,
     },
 };
 use libp2p::bytes::BytesMut;
@@ -11,8 +13,6 @@ use ssz_types::VariableList;
 use std::io::{Cursor, Read, Write};
 use tokio_util::codec::{Decoder, Encoder};
 use unsigned_varint::codec::Uvi;
-
-use super::base::OutboundCodec;
 
 const CONTEXT_BYTES_LEN: usize = 4;
 
@@ -49,7 +49,6 @@ impl Encoder<RPCCodedResponse> for SSZSnappyInboundCodec {
                 RPCResponse::MetaData(res) => res.as_ssz_bytes(),
             },
             RPCCodedResponse::Error => "".as_bytes().to_vec(),
-            RPCCodedResponse::StreamTermination => "".as_bytes().to_vec(),
         };
         Ok(())
     }

--- a/src/rpc/codec/ssz_snappy.rs
+++ b/src/rpc/codec/ssz_snappy.rs
@@ -43,11 +43,14 @@ impl Encoder<RPCCodedResponse> for SSZSnappyInboundCodec {
         _dst: &mut libp2p::bytes::BytesMut,
     ) -> Result<(), Self::Error> {
         let _bytes = match &item {
-            RPCCodedResponse::Success(m) => println!("{m:?}"),
-            RPCCodedResponse::Error => (),
-            RPCCodedResponse::StreamTermination => (),
+            RPCCodedResponse::Success(resp) => match &resp {
+                RPCResponse::Status(res) => res.as_ssz_bytes(),
+                RPCResponse::Pong(res) => res.data.as_ssz_bytes(),
+                RPCResponse::MetaData(res) => res.as_ssz_bytes(),
+            },
+            RPCCodedResponse::Error => "".as_bytes().to_vec(),
+            RPCCodedResponse::StreamTermination => "".as_bytes().to_vec(),
         };
-
         Ok(())
     }
 }

--- a/src/rpc/handler.rs
+++ b/src/rpc/handler.rs
@@ -1,57 +1,39 @@
+use super::protocol::{
+    InboundRequest, InboundSubstream, OutboundFramed, OutboundRequest, OutboundRequestContainer,
+};
 use super::{
-    codec::{InboundCodec, OutboundCodec},
     methods::RPCCodedResponse,
-    outbound::OutboundRequest,
     protocol::{Protocol, RPCError, RPCProtocol},
-    RPCReceived,
+    RPCReceived, RPCSend, ReqId,
 };
 use fnv::FnvHashMap;
-use futures::Future;
-use libp2p::swarm::{NegotiatedSubstream, SubstreamProtocol};
+use futures::{Future, FutureExt, Sink, SinkExt, StreamExt};
+use libp2p::core::UpgradeError;
+use libp2p::swarm::{
+    ConnectionHandler, ConnectionHandlerEvent, ConnectionHandlerUpgrErr, KeepAlive,
+    NegotiatedSubstream, SubstreamProtocol,
+};
+use libp2p::{InboundUpgrade, OutboundUpgrade};
 use smallvec::SmallVec;
-use std::{collections::VecDeque, pin::Pin, time::Instant};
-use tokio::time::Sleep;
-use tokio_io_timeout::TimeoutStream;
+use std::collections::hash_map::Entry;
+use std::task::Poll;
+use std::{
+    collections::VecDeque,
+    pin::Pin,
+    time::{Duration, Instant},
+};
+use tokio::time::{sleep_until, Instant as TInstant, Sleep};
 use tokio_util::time::{delay_queue, DelayQueue};
-use tokio_util::{codec::Framed, compat::Compat};
+
+const SHUTDOWN_TIMEOUT_SECS: u8 = 15;
+const MAX_INBOUND_SUBSTREAMS: usize = 32;
+const RESPONSE_TIMEOUT: u64 = 10;
+const IO_ERROR_RETRIES: u8 = 3;
 
 pub type HandlerEvent<Id> = Result<RPCReceived<Id>, &'static str>;
 
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 pub struct SubstreamId(usize);
-
-// Inbound substream info.
-pub type InboundFramed<TSocket> =
-    Framed<std::pin::Pin<Box<TimeoutStream<Compat<TSocket>>>>, InboundCodec>;
-
-type InboundSubstream = InboundFramed<NegotiatedSubstream>;
-
-// Outbound substream info.
-pub type OutboundFramed<TSocket> = Framed<Compat<TSocket>, OutboundCodec>;
-
-// RPC Handler
-pub struct RPCHandler<Id> {
-    listen_protocol: SubstreamProtocol<RPCProtocol, ()>,
-    events_out: SmallVec<[HandlerEvent<Id>; 4]>,
-    // Dialing
-    dial_queue: SmallVec<[(Id, OutboundRequest); 4]>,
-    dial_negotiated: u32,
-    // Inbound
-    inbound_substreams: FnvHashMap<SubstreamId, InboundInfo>,
-    inbound_substreams_delay: DelayQueue<SubstreamId>,
-    // Outbound
-    outbound_substreams: FnvHashMap<SubstreamId, OutboundInfo<Id>>,
-    outbound_substreams_delay: DelayQueue<SubstreamId>,
-    // Substream IDs
-    current_inbound_substream_id: SubstreamId,
-    current_outbound_substream_id: SubstreamId,
-    // Config
-    max_dial_negotiated: u32,
-    // State
-    state: HandlerState,
-    outbound_io_error_retries: u8,
-    waker: Option<std::task::Waker>,
-}
 
 // Inbound
 
@@ -93,4 +75,567 @@ enum HandlerState {
     Active,
     ShuttingDown(Pin<Box<Sleep>>),
     Deactivated,
+}
+
+// RPC Handler
+pub struct RPCHandler<Id> {
+    listen_protocol: SubstreamProtocol<RPCProtocol, ()>,
+    events_out: SmallVec<[HandlerEvent<Id>; 4]>,
+    // Dialing
+    dial_queue: SmallVec<[(Id, OutboundRequest); 4]>,
+    dial_negotiated: u32,
+    // Inbound
+    inbound_substreams: FnvHashMap<SubstreamId, InboundInfo>,
+    inbound_substreams_delay: DelayQueue<SubstreamId>,
+    // Outbound
+    outbound_substreams: FnvHashMap<SubstreamId, OutboundInfo<Id>>,
+    outbound_substreams_delay: DelayQueue<SubstreamId>,
+    // Substream IDs
+    current_inbound_substream_id: SubstreamId,
+    current_outbound_substream_id: SubstreamId,
+    // Config
+    max_dial_negotiated: u32,
+    // State
+    state: HandlerState,
+    outbound_io_error_retries: u8,
+    waker: Option<std::task::Waker>,
+}
+
+impl<Id> RPCHandler<Id> {
+    pub fn new(listen_protocol: SubstreamProtocol<RPCProtocol, ()>) -> Self {
+        Self {
+            listen_protocol,
+            events_out: SmallVec::new(),
+            dial_queue: SmallVec::new(),
+            dial_negotiated: 0,
+            inbound_substreams: FnvHashMap::default(),
+            inbound_substreams_delay: DelayQueue::new(),
+            outbound_substreams: FnvHashMap::default(),
+            outbound_substreams_delay: DelayQueue::new(),
+            current_inbound_substream_id: SubstreamId(0),
+            current_outbound_substream_id: SubstreamId(0),
+            max_dial_negotiated: 8,
+            state: HandlerState::Active,
+            outbound_io_error_retries: 0,
+            waker: None,
+        }
+    }
+
+    fn shutdown(&mut self, goodbye_reason: Option<Id>) {
+        if matches!(self.state, HandlerState::Active) {
+            while let Some((id, req)) = self.dial_queue.pop() {
+                self.events_out.push(Err("handler error"));
+            }
+
+            if let Some(id) = goodbye_reason {
+                self.dial_queue.push((id, OutboundRequest::Goodbye(1)));
+            }
+
+            self.state = HandlerState::ShuttingDown(Box::pin(sleep_until(
+                TInstant::now() + Duration::from_secs(SHUTDOWN_TIMEOUT_SECS as u64),
+            )));
+        }
+    }
+
+    fn send_request(&mut self, id: Id, req: OutboundRequest) {
+        match self.state {
+            HandlerState::Active => {
+                self.dial_queue.push((id, req));
+            }
+            _ => self.events_out.push(Err("handler error")),
+        }
+    }
+
+    fn send_response(&mut self, inbound_id: SubstreamId, response: RPCCodedResponse) {
+        let inbound_info = if let Some(info) = self.inbound_substreams.get_mut(&inbound_id) {
+            info
+        } else {
+            return;
+        };
+
+        if let RPCCodedResponse::Error = response {
+            self.events_out.push(Err("handler error"));
+        }
+
+        if matches!(self.state, HandlerState::Deactivated) {
+            return;
+        }
+
+        inbound_info.pending_items.push_back(response);
+    }
+}
+
+impl<Id> ConnectionHandler for RPCHandler<Id>
+where
+    Id: ReqId,
+{
+    type InEvent = RPCSend<Id>;
+    type OutEvent = HandlerEvent<Id>;
+    type Error = RPCError;
+    type InboundProtocol = RPCProtocol;
+    type OutboundProtocol = OutboundRequestContainer;
+    type InboundOpenInfo = ();
+    type OutboundOpenInfo = (Id, OutboundRequest);
+
+    fn listen_protocol(&self) -> SubstreamProtocol<Self::InboundProtocol, Self::InboundOpenInfo> {
+        self.listen_protocol.clone()
+    }
+
+    fn connection_keep_alive(&self) -> KeepAlive {
+        let should_shutdown = match self.state {
+            HandlerState::ShuttingDown(_) => {
+                self.dial_queue.is_empty()
+                    && self.outbound_substreams.is_empty()
+                    && self.inbound_substreams.is_empty()
+                    && self.events_out.is_empty()
+                    && self.dial_negotiated == 0
+            }
+            HandlerState::Deactivated => true,
+            _ => false,
+        };
+
+        if should_shutdown {
+            KeepAlive::No
+        } else {
+            KeepAlive::Yes
+        }
+    }
+
+    fn inject_fully_negotiated_inbound(
+        &mut self,
+        substream: <Self::InboundProtocol as InboundUpgrade<NegotiatedSubstream>>::Output,
+        _info: Self::InboundOpenInfo,
+    ) {
+        if !matches!(self.state, HandlerState::Active) {
+            return;
+        }
+
+        let (req, substream) = substream;
+        let expected_responses = req.expected_responses();
+
+        if expected_responses > 0 {
+            if self.inbound_substreams.len() < MAX_INBOUND_SUBSTREAMS {
+                let delay_key = self.inbound_substreams_delay.insert(
+                    self.current_inbound_substream_id,
+                    Duration::from_secs(RESPONSE_TIMEOUT),
+                );
+                let awaiting_stream = InboundState::Idle(substream);
+                self.inbound_substreams.insert(
+                    self.current_inbound_substream_id,
+                    InboundInfo {
+                        state: awaiting_stream,
+                        pending_items: VecDeque::with_capacity(expected_responses as usize),
+                        delay_key: Some(delay_key),
+                        protocol: req.protocol(),
+                        request_start_time: Instant::now(),
+                        remaining_chunks: expected_responses,
+                    },
+                );
+            } else {
+                self.events_out.push(Err("handler error"));
+                return self.shutdown(None);
+            }
+        }
+
+        if let InboundRequest::Goodbye(_) = req {
+            self.shutdown(None);
+        }
+
+        self.events_out.push(Ok(RPCReceived::Request(
+            self.current_inbound_substream_id,
+            req,
+        )));
+
+        self.current_inbound_substream_id.0 += 1;
+    }
+
+    fn inject_fully_negotiated_outbound(
+        &mut self,
+        out: <Self::OutboundProtocol as OutboundUpgrade<NegotiatedSubstream>>::Output,
+        request_info: Self::OutboundOpenInfo,
+    ) {
+        self.dial_negotiated -= 1;
+        let (id, request) = request_info;
+        let proto = request.protocol();
+
+        if matches!(self.state, HandlerState::Deactivated) {
+            self.events_out.push(Err("Handler Deactivated"));
+        }
+
+        let expected_responses = request.expected_responses();
+        if expected_responses > 0 {
+            let delay_key = self.outbound_substreams_delay.insert(
+                self.current_outbound_substream_id,
+                Duration::from_secs(RESPONSE_TIMEOUT),
+            );
+            let awaiting_stream = OutboundSubstreamState::RequestPendingResponse {
+                substream: Box::new(out),
+                request,
+            };
+            let expected_responses = if expected_responses > 1 {
+                Some(expected_responses)
+            } else {
+                None
+            };
+
+            self.outbound_substreams.insert(
+                self.current_outbound_substream_id,
+                OutboundInfo {
+                    state: awaiting_stream,
+                    delay_key,
+                    proto,
+                    remaining_chunks: expected_responses,
+                    req_id: id,
+                },
+            );
+
+            self.current_outbound_substream_id.0 += 1;
+        }
+    }
+
+    fn inject_event(&mut self, rpc_event: Self::InEvent) {
+        match rpc_event {
+            RPCSend::Request(id, req) => self.send_request(id, req),
+            RPCSend::Response(inbound_id, response) => self.send_response(inbound_id, response),
+        }
+
+        if let Some(waker) = &self.waker {
+            waker.wake_by_ref();
+        }
+    }
+
+    fn inject_dial_upgrade_error(
+        &mut self,
+        request_info: Self::OutboundOpenInfo,
+        error: ConnectionHandlerUpgrErr<
+            <Self::OutboundProtocol as OutboundUpgrade<NegotiatedSubstream>>::Error,
+        >,
+    ) {
+        let (id, req) = request_info;
+        if let ConnectionHandlerUpgrErr::Upgrade(UpgradeError::Apply(RPCError::Error)) = error {
+            self.outbound_io_error_retries += 1;
+            if self.outbound_io_error_retries < IO_ERROR_RETRIES {
+                self.send_request(id, req);
+                return;
+            }
+        }
+
+        self.dial_negotiated -= 1;
+
+        self.outbound_io_error_retries = 0;
+
+        self.events_out.push(Err("Handler error"));
+    }
+
+    fn poll(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<
+        libp2p::swarm::ConnectionHandlerEvent<
+            Self::OutboundProtocol,
+            Self::OutboundOpenInfo,
+            Self::OutEvent,
+            Self::Error,
+        >,
+    > {
+        if let Some(waker) = &self.waker {
+            if waker.will_wake(cx.waker()) {
+                self.waker = Some(cx.waker().clone());
+            }
+        } else {
+            self.waker = Some(cx.waker().clone());
+        }
+
+        if !self.events_out.is_empty() {
+            return Poll::Ready(ConnectionHandlerEvent::Custom(self.events_out.remove(0)));
+        } else {
+            self.events_out.shrink_to_fit();
+        }
+
+        if let HandlerState::ShuttingDown(delay) = &mut self.state {
+            match delay.as_mut().poll(cx) {
+                Poll::Ready(_) => {
+                    self.state = HandlerState::Deactivated;
+                    return Poll::Ready(ConnectionHandlerEvent::Close(RPCError::Error));
+                }
+                Poll::Pending => {}
+            };
+        }
+
+        loop {
+            match self.inbound_substreams_delay.poll_expired(cx) {
+                Poll::Ready(Some(Ok(inbound_id))) => {
+                    if let Some(info) = self.inbound_substreams.get_mut(inbound_id.get_ref()) {
+                        info.delay_key = None;
+
+                        self.events_out.push(Err("Stream Timeout"));
+
+                        if info.pending_items.back().map(|l| l.close_after()) == Some(false) {
+                            // if the last chunk does not close the stream, append an error
+                            info.pending_items.push_back(RPCCodedResponse::Error);
+                        }
+                    }
+                }
+                Poll::Ready(Some(Err(e))) => {
+                    return Poll::Ready(ConnectionHandlerEvent::Close(RPCError::Error));
+                }
+                Poll::Pending | Poll::Ready(None) => break,
+            }
+        }
+
+        loop {
+            match self.outbound_substreams_delay.poll_expired(cx) {
+                Poll::Ready(Some(Ok(outbound_id))) => {
+                    if let Some(OutboundInfo { proto, req_id, .. }) =
+                        self.outbound_substreams.remove(outbound_id.get_ref())
+                    {
+                        return Poll::Ready(ConnectionHandlerEvent::Custom(Err("Stream Timeout")));
+                    }
+                }
+                Poll::Ready(Some(Err(_))) => {
+                    return Poll::Ready(ConnectionHandlerEvent::Close(RPCError::Error));
+                }
+                Poll::Pending | Poll::Ready(None) => break,
+            }
+        }
+
+        let deactivated = matches!(self.state, HandlerState::Deactivated);
+
+        let mut substreams_to_remove = Vec::new(); // Closed substreams that need to be removed
+        for (id, info) in self.inbound_substreams.iter_mut() {
+            loop {
+                match std::mem::replace(&mut info.state, InboundState::Poisoned) {
+                    InboundState::Idle(substream) if !deactivated => {
+                        if let Some(message) = info.pending_items.pop_front() {
+                            let last_chunk = info.remaining_chunks <= 1;
+                            let fut =
+                                send_message_to_inbound_substream(substream, message, last_chunk)
+                                    .boxed();
+                            info.state = InboundState::Busy(Box::pin(fut));
+                        } else {
+                            info.state = InboundState::Idle(substream);
+                            break;
+                        }
+                    }
+                    InboundState::Idle(mut substream) => {
+                        match substream.close().poll_unpin(cx) {
+                            Poll::Pending => info.state = InboundState::Idle(substream),
+                            Poll::Ready(res) => {
+                                substreams_to_remove.push(*id);
+                                if let Some(ref delay_key) = info.delay_key {
+                                    self.inbound_substreams_delay.remove(delay_key);
+                                }
+                                if let Err(_) = res {
+                                    self.events_out.push(Err("Err"));
+                                }
+                                if info.pending_items.back().map(|l| l.close_after()) == Some(false)
+                                {
+                                    self.events_out.push(Err("Disconnected"));
+                                }
+                            }
+                        }
+                        break;
+                    }
+                    InboundState::Busy(mut fut) => {
+                        match fut.poll_unpin(cx) {
+                            Poll::Ready(Ok((substream, substream_was_closed)))
+                                if !substream_was_closed =>
+                            {
+                                info.remaining_chunks = info.remaining_chunks.saturating_sub(1);
+
+                                if let Some(ref delay_key) = info.delay_key {
+                                    self.inbound_substreams_delay
+                                        .reset(delay_key, Duration::from_secs(RESPONSE_TIMEOUT));
+                                }
+
+                                if !deactivated && !info.pending_items.is_empty() {
+                                    if let Some(message) = info.pending_items.pop_front() {
+                                        let last_chunk = info.remaining_chunks <= 1;
+                                        let fut = send_message_to_inbound_substream(
+                                            substream, message, last_chunk,
+                                        )
+                                        .boxed();
+                                        info.state = InboundState::Busy(Box::pin(fut));
+                                    }
+                                } else {
+                                    info.state = InboundState::Idle(substream);
+                                    break;
+                                }
+                            }
+                            Poll::Ready(Ok((_substream, _substream_was_closed))) => {
+                                substreams_to_remove.push(*id);
+                                if let Some(ref delay_key) = info.delay_key {
+                                    self.inbound_substreams_delay.remove(delay_key);
+                                }
+                                break;
+                            }
+                            Poll::Ready(Err(_)) => {
+                                substreams_to_remove.push(*id);
+                                if let Some(ref delay_key) = info.delay_key {
+                                    self.inbound_substreams_delay.remove(delay_key);
+                                }
+                                self.events_out.push(Err("Handler Error"));
+                                break;
+                            }
+                            Poll::Pending => {
+                                info.state = InboundState::Busy(fut);
+                                break;
+                            }
+                        };
+                    }
+                    InboundState::Poisoned => unreachable!("Poisoned inbound substream"),
+                }
+            }
+        }
+
+        for inbound_id in substreams_to_remove {
+            self.inbound_substreams.remove(&inbound_id);
+        }
+
+        for outbound_id in self.outbound_substreams.keys().copied().collect::<Vec<_>>() {
+            let (mut entry, state) = match self.outbound_substreams.entry(outbound_id) {
+                Entry::Occupied(mut entry) => {
+                    let state = std::mem::replace(
+                        &mut entry.get_mut().state,
+                        OutboundSubstreamState::Poisoned,
+                    );
+                    (entry, state)
+                }
+                Entry::Vacant(_) => unreachable!(),
+            };
+
+            match state {
+                OutboundSubstreamState::RequestPendingResponse {
+                    substream,
+                    request: _,
+                } if deactivated => {
+                    entry.get_mut().state = OutboundSubstreamState::Closing(substream);
+                    self.events_out.push(Err("RPC Disconnected"))
+                }
+                OutboundSubstreamState::RequestPendingResponse {
+                    mut substream,
+                    request,
+                } => match substream.poll_next_unpin(cx) {
+                    Poll::Ready(Some(Ok(response))) => {
+                        if request.expected_responses() > 1 && !response.close_after() {
+                            let substream_entry = entry.get_mut();
+                            let delay_key = &substream_entry.delay_key;
+
+                            let remaining_chunks = substream_entry
+                                .remaining_chunks
+                                .map(|count| count.saturating_sub(1))
+                                .unwrap_or_else(|| 0);
+                            if remaining_chunks == 0 {
+                                substream_entry.state = OutboundSubstreamState::Closing(substream);
+                            } else {
+                                substream_entry.state =
+                                    OutboundSubstreamState::RequestPendingResponse {
+                                        substream,
+                                        request,
+                                    };
+                                substream_entry.remaining_chunks = Some(remaining_chunks);
+                                self.outbound_substreams_delay
+                                    .reset(delay_key, Duration::from_secs(RESPONSE_TIMEOUT));
+                            }
+                        } else {
+                            entry.get_mut().state = OutboundSubstreamState::Closing(substream);
+                        }
+
+                        let id = entry.get().req_id;
+                        // let proto = entry.get().proto;
+
+                        let received = match response {
+                            RPCCodedResponse::Success(resp) => Ok(RPCReceived::Response(id, resp)),
+                            RPCCodedResponse::Error => Err("Handler Error"),
+                            _ => Err("Handler Error"),
+                        };
+
+                        return Poll::Ready(ConnectionHandlerEvent::Custom(received));
+                    }
+                    Poll::Ready(None) => {
+                        let delay_key = &entry.get().delay_key;
+                        // let request_id = entry.get().req_id;
+                        self.outbound_substreams_delay.remove(delay_key);
+                        entry.remove_entry();
+                    }
+                    Poll::Pending => {
+                        entry.get_mut().state =
+                            OutboundSubstreamState::RequestPendingResponse { substream, request }
+                    }
+                    Poll::Ready(Some(Err(_))) => {
+                        let delay_key = &entry.get().delay_key;
+                        self.outbound_substreams_delay.remove(delay_key);
+                        let outbound_err = "Outbound Error";
+                        entry.remove_entry();
+                        return Poll::Ready(ConnectionHandlerEvent::Custom(Err(outbound_err)));
+                    }
+                },
+                OutboundSubstreamState::Closing(mut substream) => {
+                    match Sink::poll_close(Pin::new(&mut substream), cx) {
+                        Poll::Ready(_) => {
+                            let delay_key = &entry.get().delay_key;
+                            let _protocol = entry.get().proto;
+                            let _request_id = entry.get().req_id;
+                            self.outbound_substreams_delay.remove(delay_key);
+                            entry.remove_entry();
+                        }
+                        Poll::Pending => {
+                            entry.get_mut().state = OutboundSubstreamState::Closing(substream);
+                        }
+                    }
+                }
+                OutboundSubstreamState::Poisoned => {
+                    unreachable!("Coding Error: Outbound substream is poisoned")
+                }
+            }
+        }
+
+        if !self.dial_queue.is_empty() && self.dial_negotiated < self.max_dial_negotiated {
+            self.dial_negotiated += 1;
+            let (id, req) = self.dial_queue.remove(0);
+            self.dial_queue.shrink_to_fit();
+            return Poll::Ready(ConnectionHandlerEvent::OutboundSubstreamRequest {
+                protocol: SubstreamProtocol::new(OutboundRequestContainer { req: req.clone() }, ())
+                    .map_info(|()| (id, req)),
+            });
+        }
+
+        if let HandlerState::ShuttingDown(_) = self.state {
+            if self.dial_queue.is_empty()
+                && self.outbound_substreams.is_empty()
+                && self.inbound_substreams.is_empty()
+                && self.events_out.is_empty()
+                && self.dial_negotiated == 0
+            {
+                return Poll::Ready(ConnectionHandlerEvent::Close(RPCError::Error));
+            }
+        }
+
+        Poll::Pending
+    }
+}
+
+async fn send_message_to_inbound_substream(
+    mut substream: InboundSubstream,
+    message: RPCCodedResponse,
+    last_chunk: bool,
+) -> Result<(InboundSubstream, bool), RPCError> {
+    if matches!(message, RPCCodedResponse::StreamTermination) {
+        substream.close().await.map(|_| (substream, true))
+    } else {
+        let is_error = matches!(message, RPCCodedResponse::Error);
+
+        let send_result = substream.send(message).await;
+
+        if last_chunk || is_error || send_result.is_err() {
+            let close_result = substream.close().await.map(|_| (substream, true));
+            if let Err(e) = send_result {
+                return Err(e);
+            } else {
+                return close_result;
+            }
+        }
+
+        send_result.map(|_| (substream, false))
+    }
 }

--- a/src/rpc/handler.rs
+++ b/src/rpc/handler.rs
@@ -123,7 +123,7 @@ impl<Id> RPCHandler<Id> {
 
     fn shutdown(&mut self, goodbye_reason: Option<Id>) {
         if matches!(self.state, HandlerState::Active) {
-            while let Some((id, req)) = self.dial_queue.pop() {
+            while let Some((_, _)) = self.dial_queue.pop() {
                 self.events_out.push(Err("handler error"));
             }
 
@@ -371,7 +371,6 @@ where
                         self.events_out.push(Err("Stream Timeout"));
 
                         if info.pending_items.back().map(|l| l.close_after()) == Some(false) {
-                            // if the last chunk does not close the stream, append an error
                             info.pending_items.push_back(RPCCodedResponse::Error);
                         }
                     }
@@ -386,8 +385,11 @@ where
         loop {
             match self.outbound_substreams_delay.poll_expired(cx) {
                 Poll::Ready(Some(Ok(outbound_id))) => {
-                    if let Some(OutboundInfo { proto, req_id, .. }) =
-                        self.outbound_substreams.remove(outbound_id.get_ref())
+                    if let Some(OutboundInfo {
+                        proto: _,
+                        req_id: _,
+                        ..
+                    }) = self.outbound_substreams.remove(outbound_id.get_ref())
                     {
                         return Poll::Ready(ConnectionHandlerEvent::Custom(Err("Stream Timeout")));
                     }

--- a/src/rpc/handler.rs
+++ b/src/rpc/handler.rs
@@ -37,6 +37,7 @@ pub struct SubstreamId(usize);
 
 // Inbound
 
+#[allow(dead_code)]
 struct InboundInfo {
     state: InboundState,
     pending_items: VecDeque<RPCCodedResponse>,
@@ -379,7 +380,7 @@ where
                         }
                     }
                 }
-                Poll::Ready(Some(Err(e))) => {
+                Poll::Ready(Some(Err(_))) => {
                     return Poll::Ready(ConnectionHandlerEvent::Close(RPCError::Error));
                 }
                 Poll::Pending | Poll::Ready(None) => break,
@@ -402,7 +403,7 @@ where
                         println!("timed out substream not in the books");
                     }
                 }
-                Poll::Ready(Some(Err(e))) => {
+                Poll::Ready(Some(Err(_))) => {
                     println!("Outbound substream poll failed");
                     return Poll::Ready(ConnectionHandlerEvent::Close(RPCError::Error));
                 }
@@ -412,7 +413,7 @@ where
 
         let deactivated = matches!(self.state, HandlerState::Deactivated);
 
-        let mut substreams_to_remove = Vec::new(); // Closed substreams that need to be removed
+        let mut substreams_to_remove = Vec::new();
         for (id, info) in self.inbound_substreams.iter_mut() {
             loop {
                 match std::mem::replace(&mut info.state, InboundState::Poisoned) {
@@ -557,7 +558,7 @@ where
                         }
 
                         let id = entry.get().req_id;
-                        let proto = entry.get().proto;
+                        let _proto = entry.get().proto;
 
                         let received = match response {
                             RPCCodedResponse::Success(resp) => Ok(RPCReceived::Response(id, resp)),
@@ -568,7 +569,7 @@ where
                     }
                     Poll::Ready(None) => {
                         let delay_key = &entry.get().delay_key;
-                        let request_id = entry.get().req_id;
+                        let _request_id = entry.get().req_id;
                         self.outbound_substreams_delay.remove(delay_key);
                         entry.remove_entry();
 
@@ -579,7 +580,7 @@ where
                         entry.get_mut().state =
                             OutboundSubstreamState::RequestPendingResponse { substream, request }
                     }
-                    Poll::Ready(Some(Err(e))) => {
+                    Poll::Ready(Some(Err(_))) => {
                         let delay_key = &entry.get().delay_key;
                         self.outbound_substreams_delay.remove(delay_key);
                         let outbound_err = "Stream dropped";

--- a/src/rpc/handler.rs
+++ b/src/rpc/handler.rs
@@ -1,0 +1,84 @@
+use super::{
+    codec::{InboundCodec, OutboundCodec},
+    methods::RPCCodedResponse,
+    outbound::OutboundRequest,
+    protocol::{Protocol, RPCError, RPCProtocol},
+    RPCReceived,
+};
+use fnv::FnvHashMap;
+use futures::Future;
+use libp2p::swarm::{NegotiatedSubstream, SubstreamProtocol};
+use smallvec::SmallVec;
+use std::{collections::VecDeque, pin::Pin, time::Instant};
+use tokio_io_timeout::TimeoutStream;
+use tokio_util::time::{delay_queue, DelayQueue};
+use tokio_util::{codec::Framed, compat::Compat};
+
+pub type HandlerEvent<Id> = Result<RPCReceived<Id>, &'static str>;
+
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+pub struct SubstreamId(usize);
+
+// Inbound substream info.
+pub type InboundFramed<TSocket> =
+    Framed<std::pin::Pin<Box<TimeoutStream<Compat<TSocket>>>>, InboundCodec>;
+
+type InboundSubstream = InboundFramed<NegotiatedSubstream>;
+
+// Outbound substream info.
+pub type OutboundFramed<TSocket> = Framed<Compat<TSocket>, OutboundCodec>;
+
+// RPC Handler
+pub struct RPCHandler<Id> {
+    listen_protocol: SubstreamProtocol<RPCProtocol, ()>,
+    events_out: SmallVec<[HandlerEvent<Id>; 4]>,
+    dial_queue: SmallVec<[(Id, OutboundRequest); 4]>,
+    dial_negotiated: u32,
+    // Inbound
+    inbound_substreams: FnvHashMap<SubstreamId, InboundInfo>,
+    inbound_substreams_delay: DelayQueue<SubstreamId>,
+    // Outbound
+    outbound_substreams: FnvHashMap<SubstreamId, OutboundInfo<Id>>,
+    outbound_substreams_delay: DelayQueue<SubstreamId>,
+    // Substream IDs
+    current_inbound_substream_id: SubstreamId,
+    current_outbound_substream_id: SubstreamId,
+    // Config
+    max_dial_negotiated: u32,
+}
+
+// Inbound
+
+struct InboundInfo {
+    state: InboundState,
+    pending_items: VecDeque<RPCCodedResponse>,
+    protocol: Protocol,
+    remaining_chunks: u64,
+    request_start_time: Instant,
+    delay_key: Option<delay_queue::Key>,
+}
+
+enum InboundState {
+    Idle(InboundSubstream),
+    Busy(Pin<Box<dyn Future<Output = Result<(InboundSubstream, bool), RPCError>> + Send>>),
+    Poisoned,
+}
+
+// Outbound
+
+struct OutboundInfo<Id> {
+    state: OutboundSubstreamState,
+    delay_key: delay_queue::Key,
+    proto: Protocol,
+    remaining_chunks: Option<u64>,
+    req_id: Id,
+}
+
+pub enum OutboundSubstreamState {
+    RequestPendingResponse {
+        substream: Box<OutboundFramed<NegotiatedSubstream>>,
+        request: OutboundRequest,
+    },
+    Closing(Box<OutboundFramed<NegotiatedSubstream>>),
+    Poisoned,
+}

--- a/src/rpc/methods.rs
+++ b/src/rpc/methods.rs
@@ -1,0 +1,66 @@
+use serde::Serialize;
+use ssz_derive::{Decode, Encode};
+use ssz_types::{typenum::U256, VariableList};
+use tree_hash::Hash256;
+
+/// Maximum length of error message.
+pub type MaxErrorLen = U256;
+pub const MAX_ERROR_LEN: u64 = 256;
+
+#[derive(Debug, Clone)]
+pub struct ErrorType(pub VariableList<u8, MaxErrorLen>);
+
+// https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/p2p-interface.md#messages
+
+#[derive(Encode, Decode, Clone, Debug, PartialEq)]
+pub struct StatusMessage {
+    pub fork_digest: [u8; 4],
+    pub finalized_root: Hash256,
+    pub finalized_epoch: u64,
+    pub head_root: Hash256,
+    pub head_slot: u64,
+}
+
+#[derive(Encode, Decode, Clone, Debug, PartialEq)]
+pub struct Ping {
+    pub data: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Encode, Decode)]
+pub struct MetaData {
+    pub seq_number: u64,
+}
+
+// Response
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum RPCCodedResponse {
+    Success(RPCResponse),
+    Error,
+    StreamTermination,
+}
+
+impl RPCCodedResponse {
+    pub fn as_u8(&self) -> Option<u8> {
+        match self {
+            RPCCodedResponse::Success(_) => Some(0),
+            RPCCodedResponse::Error => Some(1),
+            RPCCodedResponse::StreamTermination => None,
+        }
+    }
+
+    pub fn is_response(response_code: u8) -> bool {
+        matches!(response_code, 0)
+    }
+
+    pub fn from_error(_response_code: u8, _err: ErrorType) -> Self {
+        RPCCodedResponse::Error
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum RPCResponse {
+    Status(StatusMessage),
+    Pong(Ping),
+    MetaData(MetaData),
+}

--- a/src/rpc/methods.rs
+++ b/src/rpc/methods.rs
@@ -52,16 +52,12 @@ impl RPCCodedResponse {
     pub fn as_u8(&self) -> Option<u8> {
         match self {
             RPCCodedResponse::Success(_) => Some(0),
-            RPCCodedResponse::Error => Some(1),
+            RPCCodedResponse::Error => Some(4),
         }
     }
 
     pub fn is_response(response_code: u8) -> bool {
         matches!(response_code, 0)
-    }
-
-    pub fn from_error(_response_code: u8, _err: ErrorType) -> Self {
-        RPCCodedResponse::Error
     }
 
     pub fn close_after(&self) -> bool {

--- a/src/rpc/methods.rs
+++ b/src/rpc/methods.rs
@@ -3,9 +3,7 @@ use ssz_derive::{Decode, Encode};
 use ssz_types::{typenum::U256, VariableList};
 use tree_hash::Hash256;
 
-/// Maximum length of error message.
 pub type MaxErrorLen = U256;
-pub const MAX_ERROR_LEN: u64 = 256;
 
 #[derive(Debug, Clone)]
 pub struct ErrorType(pub VariableList<u8, MaxErrorLen>);
@@ -55,6 +53,10 @@ impl RPCCodedResponse {
 
     pub fn from_error(_response_code: u8, _err: ErrorType) -> Self {
         RPCCodedResponse::Error
+    }
+
+    pub fn close_after(&self) -> bool {
+        !matches!(self, RPCCodedResponse::Success(_))
     }
 }
 

--- a/src/rpc/methods.rs
+++ b/src/rpc/methods.rs
@@ -1,12 +1,21 @@
 use serde::Serialize;
 use ssz_derive::{Decode, Encode};
-use ssz_types::{typenum::U256, VariableList};
+use ssz_types::{
+    typenum::{U256, U4, U64},
+    BitVector, VariableList,
+};
 use tree_hash::Hash256;
 
 pub type MaxErrorLen = U256;
 
 #[derive(Debug, Clone)]
 pub struct ErrorType(pub VariableList<u8, MaxErrorLen>);
+
+pub type SubnetBitfieldLength = U64;
+pub type SyncCommitteeSubnetCount = U4;
+
+pub type EnrAttestationBitfield = BitVector<SubnetBitfieldLength>;
+pub type EnrSyncCommitteeBitfield = BitVector<SyncCommitteeSubnetCount>;
 
 // https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/p2p-interface.md#messages
 
@@ -27,6 +36,8 @@ pub struct Ping {
 #[derive(Clone, Debug, PartialEq, Serialize, Encode, Decode)]
 pub struct MetaData {
     pub seq_number: u64,
+    pub attnets: EnrAttestationBitfield,
+    pub syncnets: EnrSyncCommitteeBitfield,
 }
 
 // Response
@@ -35,7 +46,6 @@ pub struct MetaData {
 pub enum RPCCodedResponse {
     Success(RPCResponse),
     Error,
-    StreamTermination,
 }
 
 impl RPCCodedResponse {
@@ -43,7 +53,6 @@ impl RPCCodedResponse {
         match self {
             RPCCodedResponse::Success(_) => Some(0),
             RPCCodedResponse::Error => Some(1),
-            RPCCodedResponse::StreamTermination => None,
         }
     }
 

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -1,0 +1,28 @@
+pub(crate) mod codec;
+mod handler;
+pub mod methods;
+mod outbound;
+mod protocol;
+use self::methods::{RPCCodedResponse, RPCResponse};
+use self::{handler::HandlerEvent, outbound::OutboundRequest, protocol::InboundRequest};
+use libp2p::core::connection::ConnectionId;
+use libp2p::PeerId;
+
+#[derive(Debug, Clone)]
+pub enum RPCSend<Id> {
+    Request(Id, OutboundRequest),
+    Response(Id, RPCCodedResponse),
+}
+
+#[derive(Debug, Clone)]
+pub enum RPCReceived<Id> {
+    Request(Id, InboundRequest),
+    Response(Id, RPCResponse),
+}
+
+#[derive(Debug)]
+pub struct RPCMessage<Id> {
+    pub peer_id: PeerId,
+    pub conn_id: ConnectionId,
+    pub event: HandlerEvent<Id>,
+}

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -17,6 +17,7 @@ use std::task::{Context, Poll};
 pub trait ReqId: Send + 'static + std::fmt::Debug + Copy + Clone {}
 impl<T> ReqId for T where T: Send + 'static + std::fmt::Debug + Copy + Clone {}
 
+#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub enum RPCSend<Id> {
     Request(Id, OutboundRequest),
@@ -58,15 +59,13 @@ impl<Id: ReqId> RPC<Id> {
         });
     }
 
-    pub fn send_request(&mut self, peer_id: PeerId, request_id: Id, event: OutboundRequest) {
+    pub fn _send_request(&mut self, peer_id: PeerId, request_id: Id, event: OutboundRequest) {
         self.events.push(NetworkBehaviourAction::NotifyHandler {
             peer_id,
             handler: NotifyHandler::Any,
             event: RPCSend::Request(request_id, event),
         });
     }
-
-    pub fn shutdown(&mut self, peer_id: PeerId, id: Id) {}
 }
 
 impl<Id> NetworkBehaviour for RPC<Id>
@@ -108,12 +107,14 @@ where
 
 // API
 
+#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RequestId<AppReqId> {
     Application(AppReqId),
     Internal,
 }
 
+#[allow(dead_code)]
 #[derive(PartialEq)]
 pub enum Request {
     Status(StatusMessage),
@@ -127,6 +128,7 @@ impl std::convert::From<Request> for OutboundRequest {
     }
 }
 
+#[allow(dead_code)]
 #[derive(PartialEq)]
 pub enum Response {
     Status(StatusMessage),

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -86,21 +86,12 @@ where
         conn_id: ConnectionId,
         event: <Self::ConnectionHandler as ConnectionHandler>::OutEvent,
     ) {
-        if let Ok(RPCReceived::Request(ref id, ref req)) = event {
-            self.events
-                .push(NetworkBehaviourAction::GenerateEvent(RPCMessage {
-                    peer_id,
-                    conn_id,
-                    event,
-                }))
-        } else {
-            self.events
-                .push(NetworkBehaviourAction::GenerateEvent(RPCMessage {
-                    peer_id,
-                    conn_id,
-                    event,
-                }));
-        }
+        self.events
+            .push(NetworkBehaviourAction::GenerateEvent(RPCMessage {
+                peer_id,
+                conn_id,
+                event,
+            }))
     }
 
     fn poll(
@@ -123,7 +114,7 @@ pub enum RequestId<AppReqId> {
     Internal,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(PartialEq)]
 pub enum Request {
     Status(StatusMessage),
 }
@@ -136,7 +127,7 @@ impl std::convert::From<Request> for OutboundRequest {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(PartialEq)]
 pub enum Response {
     Status(StatusMessage),
 }

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -1,22 +1,31 @@
 pub(crate) mod codec;
 mod handler;
 pub mod methods;
-mod outbound;
 mod protocol;
-use self::methods::{RPCCodedResponse, RPCResponse};
-use self::{handler::HandlerEvent, outbound::OutboundRequest, protocol::InboundRequest};
+use self::handler::{RPCHandler, SubstreamId};
+use self::methods::{RPCCodedResponse, RPCResponse, StatusMessage};
+use self::protocol::{OutboundRequest, RPCProtocol};
+use self::{handler::HandlerEvent, protocol::InboundRequest};
 use libp2p::core::connection::ConnectionId;
+use libp2p::swarm::{
+    ConnectionHandler, NetworkBehaviour, NetworkBehaviourAction, NotifyHandler, PollParameters,
+    SubstreamProtocol,
+};
 use libp2p::PeerId;
+use std::task::{Context, Poll};
+
+pub trait ReqId: Send + 'static + std::fmt::Debug + Copy + Clone {}
+impl<T> ReqId for T where T: Send + 'static + std::fmt::Debug + Copy + Clone {}
 
 #[derive(Debug, Clone)]
 pub enum RPCSend<Id> {
     Request(Id, OutboundRequest),
-    Response(Id, RPCCodedResponse),
+    Response(SubstreamId, RPCCodedResponse),
 }
 
 #[derive(Debug, Clone)]
 pub enum RPCReceived<Id> {
-    Request(Id, InboundRequest),
+    Request(SubstreamId, InboundRequest),
     Response(Id, RPCResponse),
 }
 
@@ -25,4 +34,119 @@ pub struct RPCMessage<Id> {
     pub peer_id: PeerId,
     pub conn_id: ConnectionId,
     pub event: HandlerEvent<Id>,
+}
+
+pub struct RPC<Id: ReqId> {
+    events: Vec<NetworkBehaviourAction<RPCMessage<Id>, RPCHandler<Id>>>,
+}
+
+impl<Id: ReqId> RPC<Id> {
+    pub fn new() -> Self {
+        RPC { events: Vec::new() }
+    }
+
+    pub fn send_response(
+        &mut self,
+        peer_id: PeerId,
+        id: (ConnectionId, SubstreamId),
+        event: RPCCodedResponse,
+    ) {
+        self.events.push(NetworkBehaviourAction::NotifyHandler {
+            peer_id,
+            handler: NotifyHandler::One(id.0),
+            event: RPCSend::Response(id.1, event),
+        });
+    }
+
+    pub fn send_request(&mut self, peer_id: PeerId, request_id: Id, event: OutboundRequest) {
+        self.events.push(NetworkBehaviourAction::NotifyHandler {
+            peer_id,
+            handler: NotifyHandler::Any,
+            event: RPCSend::Request(request_id, event),
+        });
+    }
+
+    pub fn shutdown(&mut self, peer_id: PeerId, id: Id) {}
+}
+
+impl<Id> NetworkBehaviour for RPC<Id>
+where
+    Id: ReqId,
+{
+    type ConnectionHandler = RPCHandler<Id>;
+    type OutEvent = RPCMessage<Id>;
+
+    fn new_handler(&mut self) -> Self::ConnectionHandler {
+        RPCHandler::new(SubstreamProtocol::new(RPCProtocol {}, ()))
+    }
+
+    fn inject_event(
+        &mut self,
+        peer_id: PeerId,
+        conn_id: ConnectionId,
+        event: <Self::ConnectionHandler as ConnectionHandler>::OutEvent,
+    ) {
+        if let Ok(RPCReceived::Request(ref id, ref req)) = event {
+            self.events
+                .push(NetworkBehaviourAction::GenerateEvent(RPCMessage {
+                    peer_id,
+                    conn_id,
+                    event,
+                }))
+        } else {
+            self.events
+                .push(NetworkBehaviourAction::GenerateEvent(RPCMessage {
+                    peer_id,
+                    conn_id,
+                    event,
+                }));
+        }
+    }
+
+    fn poll(
+        &mut self,
+        cx: &mut Context,
+        _: &mut impl PollParameters,
+    ) -> Poll<NetworkBehaviourAction<Self::OutEvent, Self::ConnectionHandler>> {
+        if !self.events.is_empty() {
+            return Poll::Ready(self.events.remove(0));
+        }
+        Poll::Pending
+    }
+}
+
+// API
+
+pub type PeerRequestId = (ConnectionId, SubstreamId);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RequestId<AppReqId> {
+    Application(AppReqId),
+    Internal,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Request {
+    Status(StatusMessage),
+}
+
+impl std::convert::From<Request> for OutboundRequest {
+    fn from(req: Request) -> OutboundRequest {
+        match req {
+            Request::Status(s) => OutboundRequest::Status(s),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Response {
+    Status(StatusMessage),
+}
+
+impl std::convert::From<Response> for RPCCodedResponse {
+    fn from(resp: Response) -> RPCCodedResponse {
+        match resp {
+            Response::Status(s) => RPCCodedResponse::Success(RPCResponse::Status(s)),
+        }
+    }
 }

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -1,7 +1,7 @@
 pub(crate) mod codec;
 mod handler;
 pub mod methods;
-mod protocol;
+pub mod protocol;
 use self::handler::{RPCHandler, SubstreamId};
 use self::methods::{RPCCodedResponse, RPCResponse, StatusMessage};
 use self::protocol::{OutboundRequest, RPCProtocol};
@@ -105,7 +105,7 @@ where
 
     fn poll(
         &mut self,
-        cx: &mut Context,
+        _cx: &mut Context,
         _: &mut impl PollParameters,
     ) -> Poll<NetworkBehaviourAction<Self::OutEvent, Self::ConnectionHandler>> {
         if !self.events.is_empty() {
@@ -116,8 +116,6 @@ where
 }
 
 // API
-
-pub type PeerRequestId = (ConnectionId, SubstreamId);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RequestId<AppReqId> {

--- a/src/rpc/outbound.rs
+++ b/src/rpc/outbound.rs
@@ -1,9 +1,0 @@
-use super::methods::{Ping, StatusMessage};
-
-#[derive(Debug, Clone, PartialEq)]
-pub enum OutboundRequest {
-    Status(StatusMessage),
-    Goodbye(u64),
-    Ping(Ping),
-    MetaData,
-}

--- a/src/rpc/outbound.rs
+++ b/src/rpc/outbound.rs
@@ -1,0 +1,9 @@
+use super::methods::{Ping, StatusMessage};
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum OutboundRequest {
+    Status(StatusMessage),
+    Goodbye(u64),
+    Ping(Ping),
+    MetaData,
+}

--- a/src/rpc/protocol.rs
+++ b/src/rpc/protocol.rs
@@ -149,7 +149,8 @@ impl ProtocolName for ProtocolId {
     }
 }
 
-// Represents the ssz length bounds for RPC messages.
+// SSZ length bounds for RPC messages.
+
 #[derive(Debug, PartialEq)]
 pub struct RpcLimits {
     pub min: usize,
@@ -166,46 +167,8 @@ impl RpcLimits {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
-pub enum RPCError {
-    Error,
-}
-
-impl StdError for RPCError {
-    fn source(&self) -> Option<&(dyn StdError + 'static)> {
-        None
-    }
-
-    fn description(&self) -> &str {
-        "description() is deprecated; use Display"
-    }
-
-    fn cause(&self) -> Option<&dyn StdError> {
-        self.source()
-    }
-}
-
-impl Display for RPCError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            RPCError::Error => write!(f, "RPC Error"),
-        }
-    }
-}
-
-impl From<tokio::time::error::Elapsed> for RPCError {
-    fn from(_: tokio::time::error::Elapsed) -> Self {
-        RPCError::Error
-    }
-}
-
-impl From<io::Error> for RPCError {
-    fn from(_err: io::Error) -> Self {
-        RPCError::Error
-    }
-}
-
 // Protocol
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct RPCProtocol {}
 
@@ -219,7 +182,6 @@ impl UpgradeInfo for RPCProtocol {
             ProtocolId::new(Protocol::Goodbye, Version::V1),
             ProtocolId::new(Protocol::Ping, Version::V1),
             ProtocolId::new(Protocol::MetaData, Version::V2),
-            ProtocolId::new(Protocol::MetaData, Version::V1),
         ]
     }
 }
@@ -387,5 +349,46 @@ where
             Ok(socket)
         }
         .boxed()
+    }
+}
+
+// RPC Error
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum RPCError {
+    Error,
+}
+
+impl StdError for RPCError {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        None
+    }
+
+    fn description(&self) -> &str {
+        "description() is deprecated; use Display"
+    }
+
+    fn cause(&self) -> Option<&dyn StdError> {
+        self.source()
+    }
+}
+
+impl Display for RPCError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RPCError::Error => write!(f, "RPC Error"),
+        }
+    }
+}
+
+impl From<tokio::time::error::Elapsed> for RPCError {
+    fn from(_: tokio::time::error::Elapsed) -> Self {
+        RPCError::Error
+    }
+}
+
+impl From<io::Error> for RPCError {
+    fn from(_err: io::Error) -> Self {
+        RPCError::Error
     }
 }

--- a/src/rpc/protocol.rs
+++ b/src/rpc/protocol.rs
@@ -44,6 +44,7 @@ pub enum Protocol {
     BlocksByRoot,
     Ping,
     MetaData,
+    LightClientBootstrap,
 }
 
 impl std::fmt::Display for Protocol {
@@ -55,12 +56,29 @@ impl std::fmt::Display for Protocol {
             Protocol::BlocksByRoot => "beacon_blocks_by_root",
             Protocol::Ping => "ping",
             Protocol::MetaData => "metadata",
+            Protocol::LightClientBootstrap => "light_client_bootstrap",
         };
         f.write_str(repr)
     }
 }
 
-/// Tracks the types in a protocol id.
+// Protocol version
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Version {
+    V1,
+    V2,
+}
+
+impl std::fmt::Display for Version {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let repr = match self {
+            Version::V1 => "1",
+            Version::V2 => "2",
+        };
+        f.write_str(repr)
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct ProtocolId {
     pub message_name: Protocol,
@@ -86,7 +104,6 @@ impl ProtocolId {
     pub fn rpc_response_limits(&self) -> RpcLimits {
         match self.message_name {
             // BlocksByRange, BlocksByRoot not impl
-            // Goodbye has no response
             Protocol::Status => RpcLimits::new(
                 <StatusMessage as Encode>::ssz_fixed_len(),
                 <StatusMessage as Encode>::ssz_fixed_len(),
@@ -225,7 +242,6 @@ impl UpgradeInfo for InboundRequest {
 impl InboundRequest {
     pub fn supported_protocols(&self) -> Vec<ProtocolId> {
         match self {
-            // add more protocols when versions/encodings are supported
             InboundRequest::Status(_) => vec![ProtocolId::new(Protocol::Status)],
             InboundRequest::Goodbye(_) => vec![ProtocolId::new(Protocol::Goodbye)],
             InboundRequest::Ping(_) => vec![ProtocolId::new(Protocol::Ping)],

--- a/src/rpc/protocol.rs
+++ b/src/rpc/protocol.rs
@@ -1,0 +1,162 @@
+use super::methods::{MetaData, Ping, StatusMessage};
+use libp2p::{core::UpgradeInfo, request_response::ProtocolName};
+use ssz::Encode;
+use std::io;
+
+pub const MAX_RPC_SIZE_POST_MERGE: usize = 10 * 1_048_576; // 10 * 2**20
+
+pub const PROTOCOL_PREFIX: &str = "/eth2/beacon_chain/req";
+
+pub const PROTOCOL_SUFFIX: &str = "2/ssz_snappy";
+
+// Req/Resp Domain protocols
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Protocol {
+    Status,
+    Goodbye,
+    BlocksByRange,
+    BlocksByRoot,
+    Ping,
+    MetaData,
+}
+
+impl std::fmt::Display for Protocol {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let repr = match self {
+            Protocol::Status => "status",
+            Protocol::Goodbye => "goodbye",
+            Protocol::BlocksByRange => "beacon_blocks_by_range",
+            Protocol::BlocksByRoot => "beacon_blocks_by_root",
+            Protocol::Ping => "ping",
+            Protocol::MetaData => "metadata",
+        };
+        f.write_str(repr)
+    }
+}
+
+/// Tracks the types in a protocol id.
+#[derive(Clone, Debug)]
+pub struct ProtocolId {
+    pub message_name: Protocol,
+    protocol_id: String,
+}
+
+impl ProtocolId {
+    pub fn rpc_request_limits(&self) -> RpcLimits {
+        match self.message_name {
+            // BlocksByRange, BlocksByRoot, Goodbye not impl
+            Protocol::Status => RpcLimits::new(
+                <StatusMessage as Encode>::ssz_fixed_len(),
+                <StatusMessage as Encode>::ssz_fixed_len(),
+            ),
+            Protocol::Ping => RpcLimits::new(
+                <Ping as Encode>::ssz_fixed_len(),
+                <Ping as Encode>::ssz_fixed_len(),
+            ),
+            _ => RpcLimits::new(0, 0), // Metadata requests are empty
+        }
+    }
+
+    pub fn rpc_response_limits(&self) -> RpcLimits {
+        match self.message_name {
+            // BlocksByRange, BlocksByRoot not impl
+            // Goodbye has no response
+            Protocol::Status => RpcLimits::new(
+                <StatusMessage as Encode>::ssz_fixed_len(),
+                <StatusMessage as Encode>::ssz_fixed_len(),
+            ),
+            Protocol::Ping => RpcLimits::new(
+                <Ping as Encode>::ssz_fixed_len(),
+                <Ping as Encode>::ssz_fixed_len(),
+            ),
+            Protocol::MetaData => RpcLimits::new(0, <MetaData as Encode>::ssz_fixed_len()),
+            _ => RpcLimits::new(0, 0),
+        }
+    }
+
+    pub fn has_context_bytes(&self) -> bool {
+        match self.message_name {
+            Protocol::BlocksByRange | Protocol::BlocksByRoot => true,
+            _ => false,
+        }
+    }
+}
+
+impl ProtocolId {
+    pub fn new(message_name: Protocol) -> Self {
+        let protocol_id = format!("{}/{}/{}", PROTOCOL_PREFIX, message_name, PROTOCOL_SUFFIX);
+
+        ProtocolId {
+            message_name,
+            protocol_id,
+        }
+    }
+}
+
+impl ProtocolName for ProtocolId {
+    fn protocol_name(&self) -> &[u8] {
+        self.protocol_id.as_bytes()
+    }
+}
+
+// Represents the ssz length bounds for RPC messages.
+#[derive(Debug, PartialEq)]
+pub struct RpcLimits {
+    pub min: usize,
+    pub max: usize,
+}
+
+impl RpcLimits {
+    pub fn new(min: usize, max: usize) -> Self {
+        Self { min, max }
+    }
+
+    pub fn is_out_of_bounds(&self, length: usize, max_rpc_size: usize) -> bool {
+        length > std::cmp::min(self.max, max_rpc_size) || length < self.min
+    }
+}
+
+pub enum RPCError {
+    Error,
+}
+
+impl From<tokio::time::error::Elapsed> for RPCError {
+    fn from(_: tokio::time::error::Elapsed) -> Self {
+        RPCError::Error
+    }
+}
+
+impl From<io::Error> for RPCError {
+    fn from(_err: io::Error) -> Self {
+        RPCError::Error
+    }
+}
+
+// Protocol
+pub struct RPCProtocol {}
+
+impl UpgradeInfo for RPCProtocol {
+    type Info = ProtocolId;
+    type InfoIter = Vec<Self::Info>;
+
+    /// The list of supported RPC protocols for Lighthouse.
+    fn protocol_info(&self) -> Self::InfoIter {
+        vec![
+            ProtocolId::new(Protocol::Status),
+            ProtocolId::new(Protocol::Goodbye),
+            ProtocolId::new(Protocol::BlocksByRange),
+            ProtocolId::new(Protocol::BlocksByRoot),
+            ProtocolId::new(Protocol::Ping),
+            ProtocolId::new(Protocol::MetaData),
+        ]
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum InboundRequest {
+    Status(StatusMessage),
+    Goodbye(u64),
+    Ping(Ping),
+    MetaData,
+}

--- a/src/rpc/protocol.rs
+++ b/src/rpc/protocol.rs
@@ -35,6 +35,7 @@ const TTFB_TIMEOUT: u64 = 5;
 const REQUEST_TIMEOUT: u64 = 15;
 
 // Req/Resp Domain protocols
+#[allow(dead_code)]
 #[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Protocol {
@@ -87,7 +88,7 @@ pub struct ProtocolId {
 }
 
 impl ProtocolId {
-    pub fn rpc_request_limits(&self) -> RpcLimits {
+    pub fn _rpc_request_limits(&self) -> RpcLimits {
         match self.message_name {
             // BlocksByRange, BlocksByRoot, Goodbye not impl
             Protocol::Status => RpcLimits::new(
@@ -120,7 +121,7 @@ impl ProtocolId {
         }
     }
 
-    pub fn has_context_bytes(&self) -> bool {
+    pub fn _has_context_bytes(&self) -> bool {
         match self.message_name {
             Protocol::BlocksByRange | Protocol::BlocksByRoot => true,
             _ => false,
@@ -188,6 +189,7 @@ impl UpgradeInfo for RPCProtocol {
 
 // Inbound
 
+#[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq)]
 pub enum InboundRequest {
     Status(StatusMessage),
@@ -285,6 +287,7 @@ impl UpgradeInfo for OutboundRequestContainer {
     }
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq)]
 pub enum OutboundRequest {
     Status(StatusMessage),


### PR DESCRIPTION
# Description

This PR adds the capabilities to support the Req/Res Protocol that enables direct communication between two consensus layer peers.

# Limitations

The changes in this PR do not include capabilities to switch among different specs, and are also aimed towards providing responses to the requests that could incur in bad peer scoring if not replied. However, it's still possible to make requests to peers.